### PR TITLE
fix: move code copy button to the top right corner

### DIFF
--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -152,3 +152,14 @@ a.header-twitter-link:hover{
   font-size: 20px;
   line-height: 44px;
 }
+
+.codeBlockContent_node_modules-\@docusaurus-theme-classic-lib-theme-CodeBlock-Content-styles-module {
+  display: flex;
+  justify-content: space-between;
+}
+
+.buttonGroup_node_modules-\@docusaurus-theme-classic-lib-theme-CodeBlock-Content-styles-module {
+  display: block !important; 
+  position: relative !important;
+  margin-top: 5px;
+}


### PR DESCRIPTION
<!--
Thank you for contributing to Vanus Documentation!
PR Title Format: 
style/docs/ci/chore/...: what's changed
Note: see https://github.com/vanus-labs/docs/blob/main/CONTRIBUTING.md#commit-message-style to know more about title format
-->

### Related Issue

Solving Issue: #xxx

### PR Summary

fix: move code copy button to the top right corner'
@yuanmoon please review it

### PR Type

<!-- At least one of them should be chosen. 
It's recommended to solve only one problem in each PR.
-->

- [ ] Fix typos or format(punctuation, space, indentation, code block, etc.)
- [ ] Update inappropriate or misunderstanding content
- [ ] Add missing content or new documents
- [ ] Delete useless content or outdated documents
- [ ] Localize or translate documents
- [ ] Deal with GitHub action files and scripts
- [ ] Deal with chores